### PR TITLE
[TASK] create constraints should return constraints

### DIFF
--- a/Classes/Domain/Repository/AbstractDemandRepository.php
+++ b/Classes/Domain/Repository/AbstractDemandRepository.php
@@ -79,7 +79,6 @@ abstract class AbstractDemandRepository extends Repository implements DemandRepo
         $query = $this->createQuery();
 
         $this->setStorage($query, $demand);
-        $this->createConstraints($query, $demand);
         $this->setOrderings($query, $demand);
 
         if ($demand->getLimit()) {
@@ -88,6 +87,19 @@ abstract class AbstractDemandRepository extends Repository implements DemandRepo
         if ($demand->getOffSet()) {
             $query->setOffset($demand->getOffSet());
         }
+
+        $constraints = $this->createConstraints($query, $demand);
+
+        if (!empty($constraints)) {
+            $query->matching(
+                $this->createConstraintFromConstraintsArray(
+                    $query,
+                    $constraints,
+                    'and'
+                )
+            );
+        }
+
         return $query;
     }
 
@@ -164,7 +176,7 @@ abstract class AbstractDemandRepository extends Repository implements DemandRepo
     /**
      * @param QueryInterface $query
      * @param Demand $demand
-     * @return void
+     * @return array
      */
-    abstract protected function createConstraints(QueryInterface $query, Demand $demand);
+    abstract protected function createConstraints(QueryInterface $query, Demand $demand): array;
 }

--- a/Classes/Domain/Repository/ProductRepository.php
+++ b/Classes/Domain/Repository/ProductRepository.php
@@ -278,8 +278,9 @@ class ProductRepository extends AbstractDemandRepository
      *
      * @param QueryInterface $query
      * @param Demand $demand
+     * @return array
      */
-    protected function createConstraints(QueryInterface $query, Demand $demand)
+    protected function createConstraints(QueryInterface $query, Demand $demand): array
     {
         $constraints = [];
 
@@ -306,15 +307,7 @@ class ProductRepository extends AbstractDemandRepository
             }
         }
 
-        if (!empty($constraints)) {
-            $query->matching(
-                $this->createConstraintFromConstraintsArray(
-                    $query,
-                    $constraints,
-                    'and'
-                )
-            );
-        }
+        return $constraints;
     }
 
     /**

--- a/Tests/Unit/Domain/Repository/ProductRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/ProductRepositoryTest.php
@@ -25,20 +25,16 @@ class ProductRepositoryTest extends UnitTestCase
         $mockedQuery = $this->createMock(QueryInterface::class);
         $mockedRepository = $this->getAccessibleMock(
             ProductRepository::class,
-            ['createConstraintFromConstraintsArray', 'createDiscontinuedConstraints'],
+            ['createDiscontinuedConstraints'],
             [],
             '',
             false
         );
 
         $mockedRepository
-            ->expects($this->never())
-            ->method('createConstraintFromConstraintsArray');
-
-            $mockedRepository
-            ->expects($this->never())
-            ->method('createDiscontinuedConstraints')
-            ->with($mockedQuery);
+        ->expects($this->never())
+        ->method('createDiscontinuedConstraints')
+        ->with($mockedQuery);
 
         $demand = new Demand();
         $demand->setIncludeDiscontinued(true);
@@ -54,7 +50,7 @@ class ProductRepositoryTest extends UnitTestCase
         $mockedQuery = $this->createMock(QueryInterface::class);
         $mockedRepository = $this->getAccessibleMock(
             ProductRepository::class,
-            ['createConstraintFromConstraintsArray', 'createDiscontinuedConstraints'],
+            ['createDiscontinuedConstraints'],
             [],
             '',
             false
@@ -65,13 +61,10 @@ class ProductRepositoryTest extends UnitTestCase
             ->method('createDiscontinuedConstraints')
             ->with($mockedQuery);
 
-        $mockedRepository
-            ->expects($this->once())
-            ->method('createConstraintFromConstraintsArray');
-
         $demand = new Demand();
 
-        $mockedRepository->_call('createConstraints', $mockedQuery, $demand);
+        $constraints = $mockedRepository->_call('createConstraints', $mockedQuery, $demand);
+        $this->assertTrue(array_key_exists('discontinued', $constraints));
     }
 
     /**
@@ -95,7 +88,6 @@ class ProductRepositoryTest extends UnitTestCase
         $mockedRepository = $this->getAccessibleMock(
             ProductRepository::class,
             [
-                'createConstraintFromConstraintsArray',
                 'createFilteringConstraints',
                 'createCategoryConstraints',
                 'createDiscontinuedConstraints'
@@ -121,12 +113,11 @@ class ProductRepositoryTest extends UnitTestCase
             ->method('createDiscontinuedConstraints')
             ->with($mockedQuery);
 
-        $mockedRepository
-            ->expects($this->once())
-            ->method('createConstraintFromConstraintsArray');
 
+        $constraints = $mockedRepository->_call('createConstraints', $mockedQuery, $demand);
 
-        $mockedRepository->_call('createConstraints', $mockedQuery, $demand);
+        $expectConstraints = ['categories', 'filters'];
+        $this->assertEquals($expectConstraints, array_keys($constraints));
     }
 
     /**
@@ -149,7 +140,6 @@ class ProductRepositoryTest extends UnitTestCase
         $mockedRepository = $this->getAccessibleMock(
             ProductRepository::class,
             [
-                'createConstraintFromConstraintsArray',
                 'createFilteringConstraints',
                 'createCategoryConstraints',
                 'createDiscontinuedConstraints'
@@ -175,12 +165,10 @@ class ProductRepositoryTest extends UnitTestCase
             ->method('createDiscontinuedConstraints')
             ->with($mockedQuery);
 
-        $mockedRepository
-            ->expects($this->once())
-            ->method('createConstraintFromConstraintsArray');
+        $constraints = $mockedRepository->_call('createConstraints', $mockedQuery, $demand);
 
-
-        $mockedRepository->_call('createConstraints', $mockedQuery, $demand);
+        $expectConstraints = ['discontinued', 'categories', 'filters'];
+        $this->assertEquals($expectConstraints, array_keys($constraints));
     }
 
     /**


### PR DESCRIPTION
Create constraints should return constraints to create demand method. This make it easier to manipulate constraints in child object