### PR TITLE
[BUGFIX] clone attribute set in attribute holder utility

### DIFF
--- a/Classes/Utility/AttributeHolderUtility.php
+++ b/Classes/Utility/AttributeHolderUtility.php
@@ -108,7 +108,7 @@ class AttributeHolderUtility
                     }
                 }
 
-                // Save generated attribute
+                // Save generated attribute set
                 $attributesSetClone = clone $attributesSet;
                 $attributesSetClone->setAttributes($currentSetAttributes);
 

--- a/Classes/Utility/AttributeHolderUtility.php
+++ b/Classes/Utility/AttributeHolderUtility.php
@@ -108,9 +108,11 @@ class AttributeHolderUtility
                     }
                 }
 
-                // set new attributes
-                $attributesSet->setAttributes($currentSetAttributes);
-                $this->attributeSets->attach($attributesSet);
+                // Save generated attribute
+                $attributesSetClone = clone $attributesSet;
+                $attributesSetClone->setAttributes($currentSetAttributes);
+
+                $this->attributeSets->attach($attributesSetClone);
             }
         }
     }


### PR DESCRIPTION
clone attribute set in attribute holder utility in order to avoid using same attribute instance for other products in initializeAttributes