### PR TITLE
Fixes link navigation

### DIFF
--- a/Classes/ViewHelpers/Link/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/LinkViewHelper.php
@@ -58,7 +58,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
      */
     public function render()
     {
-        $pageUid = intval($this->arguments['pagePid'] ?? $GLOBALS['TSFE']->id);
+        $pageUid = intval($this->arguments['pageUid'] ?? $GLOBALS['TSFE']->id);
         $product = $this->arguments['product'];
         $category = $this->arguments['category'];
         $target = $this->arguments['target'];

--- a/Classes/ViewHelpers/Link/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/LinkViewHelper.php
@@ -43,7 +43,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
 
         $this->registerArgument('product', 'mixed', 'Product to link to single view', false, null);
         // @codingStandardsIgnoreStart
-        $this->registerArgument('category', 'mixed', 'Category to link to list view or product sinle view', false, null);
+        $this->registerArgument('category', 'mixed', 'Category to link to list view or product single view', false, null);
         // @codingStandardsIgnoreEnd
         $this->registerArgument('pageUid', 'int', 'Target page uid', false, null);
         $this->registerArgument('excludeCategories', 'bool', 'Exclude categories from path', false, false);

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -22,6 +22,10 @@ plugin.tx_pxaproductmanager {
 
     }
 
+    mvc {
+        callDefaultActionIfActionCantBeResolved = 1
+    }
+
     settings {
         # pid
         pagePid = {$plugin.tx_pxaproductmanager.settings.pagePid}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,7 +1,4 @@
 <?php
-
-use Pixelant\PxaProductManager\Backend\FormDataProvider\OrderEditFormInitialize;
-
 defined('TYPO3_MODE') || die;
 
 call_user_func(
@@ -52,7 +49,7 @@ call_user_func(
             ]
         ];
 
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][OrderEditFormInitialize::class] = [
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\Pixelant\PxaProductManager\Backend\FormDataProvider\OrderEditFormInitialize::class] = [
             'depends' => [
                 \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::class
             ]


### PR DESCRIPTION
1. Fix typo when fetching page UID from arguments, fixes #120
2. Fix typo in argument description
3. Remove use from ext_localconf.php
4. Modify mvc settings that allow to call default action and cotroller in order to fix navigation mode with new link builder. Fixes #121 