### PR TITLE
Link builder

### DIFF
--- a/Classes/Configuration/ConfigurationManager.php
+++ b/Classes/Configuration/ConfigurationManager.php
@@ -13,7 +13,7 @@ namespace Pixelant\PxaProductManager\Configuration;
  *
  * The TYPO3 project - inspiring people to share!
  */
-use Pixelant\PxaProductManager\Configuration\BackendConfigurationManager;
+
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager as ExtbaseConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager;
 

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -88,6 +88,7 @@ class Category extends CategoryExtbase
      * Attribute sets
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Pixelant\PxaProductManager\Domain\Model\AttributeSet>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
     protected $attributeSets;
 

--- a/Classes/LinkHandler/ProductLinkBuilder.php
+++ b/Classes/LinkHandler/ProductLinkBuilder.php
@@ -28,14 +28,39 @@ namespace Pixelant\PxaProductManager\LinkHandler;
 
 use Pixelant\PxaProductManager\Service\Link\LinkBuilderService;
 use Pixelant\PxaProductManager\Utility\ConfigurationUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\ImmediateResponseException;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteInterface;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\ErrorController;
 use TYPO3\CMS\Frontend\Typolink\AbstractTypolinkBuilder;
 
 class ProductLinkBuilder extends AbstractTypolinkBuilder
 {
+    /**
+     * Link builder modes
+     */
+    const PRODUCT_MODE = 1;
+    const CATEGORY_MODE = 2;
+
+    /**
+     * Product or category UID
+     *
+     * @var int
+     */
+    protected $recordUid = 0;
+
+    /**
+     * Determinate builder mode
+     *
+     * @var int
+     */
+    protected $mode = 0;
+
     /**
      * Generates link to product single view
      *
@@ -49,29 +74,26 @@ class ProductLinkBuilder extends AbstractTypolinkBuilder
     {
         $finalUrl = '';
 
-        if (isset($linkDetails['product']) || isset($linkDetails['category'])) {
-            $singleViewPageUid = ConfigurationUtility::getSettingsByPath('pagePid');
+        $this->defineBuilderMode($linkDetails);
 
-            if (empty($singleViewPageUid) && !empty($GLOBALS['TYPO3_REQUEST'])) {
-                /** @var Site $site */
-                $site = $GLOBALS['TYPO3_REQUEST']->getAttribute('site');
-                $singleViewPageUid = $site->getConfiguration()['productSingleViewFallbackPid'];
+        $singleViewPageUid = ConfigurationUtility::getSettingsByPath('pagePid');
 
-                if (empty($singleViewPageUid) || (int)$singleViewPageUid === 0) {
-                    $response = GeneralUtility::makeInstance(ErrorController::class)->pageNotFoundAction(
-                        $GLOBALS['TYPO3_REQUEST'],
-                        'The requested product single view page was not found',
-                        ['The fallback pid is not set']
-                    );
-                    throw new ImmediateResponseException($response, 1533931329);
-                }
-            }
+        if (empty($singleViewPageUid) && ($site = $this->getSite())) {
+            $singleViewPageUid = $site->getConfiguration()['productSingleViewFallbackPid'];
+        }
 
+        $singleViewPageUid = (int)$singleViewPageUid;
+        if ($singleViewPageUid > 0) {
             $linkBuilder = $this->getLinkBuilder();
 
-            $finalUrl = isset($linkDetails['product'])
-                ? $linkBuilder->buildForProduct((int)$singleViewPageUid, (int)$linkDetails['product'])
-                : $linkBuilder->buildForCategory((int)$singleViewPageUid, (int)$linkDetails['category']);
+            switch ($this->mode) {
+                case self::PRODUCT_MODE:
+                    $finalUrl = $linkBuilder->buildForProduct($singleViewPageUid, $this->recordUid);
+                    break;
+                case self::CATEGORY_MODE:
+                    $finalUrl = $linkBuilder->buildForCategory($singleViewPageUid, $this->recordUid);
+                    break;
+            }
         }
 
         return [$finalUrl, $linkText, $target];
@@ -89,5 +111,70 @@ class ProductLinkBuilder extends AbstractTypolinkBuilder
             null, // Detect language automatically
             $this->getTypoScriptFrontendController() // Pass give TypoScriptFrontendController
         );
+    }
+
+    /**
+     * Define link builder mode
+     *
+     * @param array $linkDetails
+     */
+    protected function defineBuilderMode(array $linkDetails): void
+    {
+        if (isset($linkDetails['product'])) {
+            $this->mode = self::PRODUCT_MODE;
+            $this->recordUid = (int)$linkDetails['product'];
+
+            return;
+        }
+
+        if (isset($linkDetails['category'])) {
+            $this->mode = self::CATEGORY_MODE;
+            $this->recordUid = (int)$linkDetails['category'];
+
+            return;
+        }
+
+        // @codingStandardsIgnoreStart
+        throw new \InvalidArgumentException('Product or Category shall be provided for product link builder', 1557304991448);
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * Get site entry from request or try to find by record Pid
+     *
+     * @return Site|null
+     */
+    protected function getSite(): ?Site
+    {
+        if (isset($GLOBALS['TYPO3_REQUEST'])) {
+            /** @var Site $site */
+            $site = $GLOBALS['TYPO3_REQUEST']->getAttribute('site');
+        }
+        // Try to find site by record PID
+        if (isset($site) && $site instanceof NullSite) {
+            $table = $this->mode === self::PRODUCT_MODE
+                ? 'tx_pxaproductmanager_domain_model_product'
+                : 'sys_category';
+
+            $pid = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getConnectionForTable($table)
+                ->select(
+                    ['pid'],
+                    $table,
+                    ['uid' => $this->recordUid]
+                )
+                ->fetchColumn(0);
+            
+            if ($pid > 0) {
+                $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+                try {
+                    return $siteFinder->getSiteByPageId((int)$pid);
+                } catch (SiteNotFoundException $exception) {
+                    // Just return null
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/Classes/LinkHandler/ProductLinkBuilder.php
+++ b/Classes/LinkHandler/ProductLinkBuilder.php
@@ -146,12 +146,13 @@ class ProductLinkBuilder extends AbstractTypolinkBuilder
      */
     protected function getSite(): ?Site
     {
-        if (isset($GLOBALS['TYPO3_REQUEST'])) {
-            /** @var Site $site */
-            $site = $GLOBALS['TYPO3_REQUEST']->getAttribute('site');
-        }
+        /** @var Site $site */
+        $site = isset($GLOBALS['TYPO3_REQUEST'])
+            ? $GLOBALS['TYPO3_REQUEST']->getAttribute('site')
+            : null;
+
         // Try to find site by record PID
-        if (isset($site) && $site instanceof NullSite) {
+        if ($site === null || $site instanceof NullSite) {
             $table = $this->mode === self::PRODUCT_MODE
                 ? 'tx_pxaproductmanager_domain_model_product'
                 : 'sys_category';
@@ -164,17 +165,18 @@ class ProductLinkBuilder extends AbstractTypolinkBuilder
                     ['uid' => $this->recordUid]
                 )
                 ->fetchColumn(0);
-            
+
             if ($pid > 0) {
                 $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
                 try {
                     return $siteFinder->getSiteByPageId((int)$pid);
                 } catch (SiteNotFoundException $exception) {
                     // Just return null
+                    return null;
                 }
             }
         }
 
-        return null;
+        return $site;
     }
 }

--- a/Classes/LinkHandler/ProductLinkBuilder.php
+++ b/Classes/LinkHandler/ProductLinkBuilder.php
@@ -84,6 +84,10 @@ class ProductLinkBuilder extends AbstractTypolinkBuilder
      */
     protected function getLinkBuilder(): LinkBuilderService
     {
-        return GeneralUtility::makeInstance(LinkBuilderService::class);
+        return GeneralUtility::makeInstance(
+            LinkBuilderService::class,
+            null, // Detect language automatically
+            $this->getTypoScriptFrontendController() // Pass give TypoScriptFrontendController
+        );
     }
 }

--- a/Classes/Service/Link/LinkBuilderService.php
+++ b/Classes/Service/Link/LinkBuilderService.php
@@ -61,7 +61,7 @@ class LinkBuilderService
     ) {
         if ($languageUid !== null) {
             $this->languageUid = $languageUid;
-        } elseif (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) {
+        } elseif ($this->isFrontendRequestType()) {
             /** @var LanguageAspect $languageAspect */
             $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
             $this->languageUid = $languageAspect->getId();
@@ -272,5 +272,19 @@ class LinkBuilderService
         static::$cacheCategories[$categoryUid] = $arguments;
 
         return $arguments;
+    }
+
+    /**
+     * Check if FE request
+     *
+     * @return bool
+     */
+    protected function isFrontendRequestType(): bool
+    {
+        if (!defined('TYPO3_REQUESTTYPE')) {
+            return false;
+        }
+
+        return (bool)(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE);
     }
 }

--- a/Classes/Service/Link/LinkBuilderService.php
+++ b/Classes/Service/Link/LinkBuilderService.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class LinkBuilderService
@@ -36,6 +37,11 @@ class LinkBuilderService
     protected static $cacheCategories = [];
 
     /**
+     * @var TypoScriptFrontendController
+     */
+    protected $typoScriptFrontendController = null;
+
+    /**
      * Language uid
      *
      * @var int
@@ -46,9 +52,13 @@ class LinkBuilderService
      * Initialize
      *
      * @param int|null $languageUid Provide language to generate urls
+     * @param TypoScriptFrontendController|null $typoScriptFrontendController
+     * @throws \TYPO3\CMS\Core\Context\Exception\AspectNotFoundException
      */
-    public function __construct(int $languageUid = null)
-    {
+    public function __construct(
+        int $languageUid = null,
+        TypoScriptFrontendController $typoScriptFrontendController = null
+    ) {
         if ($languageUid !== null) {
             $this->languageUid = $languageUid;
         } elseif (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) {
@@ -56,6 +66,8 @@ class LinkBuilderService
             $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
             $this->languageUid = $languageAspect->getId();
         }
+
+        $this->typoScriptFrontendController = $typoScriptFrontendController;
     }
 
     /**
@@ -186,7 +198,10 @@ class LinkBuilderService
         $this->emitSignal(__CLASS__, 'beforeBuildUri', $signalArguments);
 
         /** @var ContentObjectRenderer $contentObjectRenderer */
-        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $contentObjectRenderer = GeneralUtility::makeInstance(
+            ContentObjectRenderer::class,
+            $this->typoScriptFrontendController
+        );
         return $contentObjectRenderer->typolink_URL($confLink);
     }
 

--- a/Tests/Functional/LinkHandler/ProductLinkBuilderTest.php
+++ b/Tests/Functional/LinkHandler/ProductLinkBuilderTest.php
@@ -6,7 +6,7 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Pixelant\PxaProductManager\LinkHandler\ProductLinkBuilder;
 use Pixelant\PxaProductManager\Service\Link\LinkBuilderService;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Core\Site\Entity\Site;
 
 /**
  * Class ProductLinkBuilderTest
@@ -27,18 +27,7 @@ class ProductLinkBuilderTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../Fixtures/sys_category.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_pxaproductmanager_domain_model_product.xml');
 
-        $this->productLinkBuilder = $this->createPartialMock(ProductLinkBuilder::class, ['getLinkBuilder']);
-
-        $tsfe = $this->createMock(TypoScriptFrontendController::class);
-
-        $tmpl = new \stdClass();
-        $tmpl->setup['plugin.']['tx_pxaproductmanager.']['settings.'] = [
-            'pagePid' => 123
-        ];
-
-        $tsfe->tmpl = $tmpl;
-
-        $GLOBALS['TSFE'] = $tsfe;
+        $this->productLinkBuilder = $this->createPartialMock(ProductLinkBuilder::class, ['getLinkBuilder', 'getSite']);
     }
 
     /**
@@ -66,6 +55,17 @@ class ProductLinkBuilderTest extends FunctionalTestCase
         $linkText = 'Test link';
         $target = '';
 
+        $site = $this->createPartialMock(Site::class, ['getConfiguration']);
+        $site
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn(['productSingleViewFallbackPid' => 1]);
+
+        $this->productLinkBuilder
+            ->expects($this->once())
+            ->method('getSite')
+            ->willReturn($site);
+
         $mockedLinkBuilder = $this->createPartialMock(LinkBuilderService::class, ['buildForProduct']);
         $mockedLinkBuilder
             ->expects($this->once())
@@ -88,6 +88,17 @@ class ProductLinkBuilderTest extends FunctionalTestCase
         $linkText = 'Test link';
         $target = '';
 
+        $site = $this->createPartialMock(Site::class, ['getConfiguration']);
+        $site
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn(['productSingleViewFallbackPid' => 1]);
+
+        $this->productLinkBuilder
+            ->expects($this->once())
+            ->method('getSite')
+            ->willReturn($site);
+
         $mockedLinkBuilder = $this->createPartialMock(LinkBuilderService::class, ['buildForCategory']);
         $mockedLinkBuilder
             ->expects($this->once())
@@ -103,6 +114,6 @@ class ProductLinkBuilderTest extends FunctionalTestCase
 
     protected function tearDown()
     {
-        unset($GLOBALS['TSFE']);
+        unset($this->productLinkBuilder);
     }
 }

--- a/Tests/Unit/LinkHandler/ProductLinkBuilderTest.php
+++ b/Tests/Unit/LinkHandler/ProductLinkBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Pixelant\PxaProductManager\Tests\Unit\LinkHandler;
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Pixelant\PxaProductManager\LinkHandler\ProductLinkBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+/**
+ * Class ProductLinkBuilderTest
+ * @package Pixelant\PxaProductManager\Tests\Unit\LinkHandler
+ */
+class ProductLinkBuilderTest extends UnitTestCase
+{
+    /**
+     * @var ProductLinkBuilder|MockObject
+     */
+    protected $subject = null;
+
+    public function setUp()
+    {
+        $this->subject = $this->getAccessibleMock(
+            ProductLinkBuilder::class,
+            ['getTypoScriptFrontendController'],
+            [],
+            '',
+            false,
+            false
+        );
+    }
+
+    public function tearDown()
+    {
+        unset($this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function getLinkBuilderPassGiveTypoScriptFrontendController()
+    {
+        $this->subject
+            ->expects($this->once())
+            ->method('getTypoScriptFrontendController');
+
+        $this->subject->_call('getLinkBuilder');
+    }
+
+    /**
+     * @test
+     */
+    public function productLinkBuilderModeDefinedIfProductGivenInLinkDetails()
+    {
+        $linkDetails = [
+            'product' => 123
+        ];
+
+        $this->subject->_call('defineBuilderMode', $linkDetails);
+
+        $this->assertEquals(ProductLinkBuilder::PRODUCT_MODE, $this->subject->_get('mode'));
+        $this->assertEquals(123, $this->subject->_get('recordUid'));
+    }
+
+    /**
+     * @test
+     */
+    public function categoryLinkBuilderModeDefinedIfCategoryGivenInLinkDetails()
+    {
+        $linkDetails = [
+            'category' => 321
+        ];
+
+        $this->subject->_call('defineBuilderMode', $linkDetails);
+
+        $this->assertEquals(ProductLinkBuilder::CATEGORY_MODE, $this->subject->_get('mode'));
+        $this->assertEquals(321, $this->subject->_get('recordUid'));
+    }
+
+    /**
+     * @test
+     */
+    public function defineBuilderModeThrowExcpetionIfNeitherProductNorCategoryGiven()
+    {
+        $linkDetails = [];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->subject->_call('defineBuilderMode', $linkDetails);
+    }
+
+    /**
+     * @test
+     */
+    public function ifTypo3RequestProvideValidSiteItsReturned()
+    {
+        $site = $this->createMock(Site::class);
+
+        $request = $this->createPartialMock(ServerRequest::class, ['getAttribute']);
+        $request
+            ->expects($this->once())
+            ->method('getAttribute')
+            ->with('site')
+            ->willReturn($site);
+
+        $requestBackup = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $resultSite = $this->subject->_call('getSite');
+
+        $GLOBALS['TYPO3_REQUEST'] = $requestBackup;
+
+        $this->assertSame($site, $resultSite);
+    }
+}

--- a/Tests/Unit/Service/Link/LinkBuilderServiceTest.php
+++ b/Tests/Unit/Service/Link/LinkBuilderServiceTest.php
@@ -7,6 +7,7 @@ use Pixelant\PxaProductManager\Domain\Model\Category;
 use Pixelant\PxaProductManager\Domain\Model\Product;
 use Pixelant\PxaProductManager\Service\Link\LinkBuilderService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Class LinkBuilderServiceTest
@@ -58,6 +59,30 @@ class LinkBuilderServiceTest extends UnitTestCase
         );
 
         $this->assertEquals($languageUid, $subject->_get('languageUid'));
+    }
+
+    /**
+     * @test
+     */
+    public function defaultTypoScriptFrontendControllerIsNull()
+    {
+        $this->assertNull($this->subject->_get('typoScriptFrontendController'));
+    }
+
+    /**
+     * @test
+     */
+    public function typoScriptFrontendControllerPassedToConstructorIsSet()
+    {
+        $tsfe = $this->createMock(TypoScriptFrontendController::class);
+
+        $subject = $this->getAccessibleMock(
+            LinkBuilderService::class,
+            null,
+            [null, $tsfe]
+        );
+
+        $this->assertSame($tsfe, $subject->_get('typoScriptFrontendController'));
     }
 
     /**


### PR DESCRIPTION
1. Rebuild product link builder in order to use given TypoScriptFrontendController from RedirectService in redirect middleware.
2. Fetch site by record Pid. Fix links preview in redirects module. 