### PR TITLE
Restore category creation with MySQL strict mode

### DIFF
--- a/Configuration/TCA/Overrides/sys_category.php
+++ b/Configuration/TCA/Overrides/sys_category.php
@@ -258,6 +258,7 @@ call_user_func(function () {
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
+                'default' => 0,
                 'size' => 1,
                 'max_size' => 1,
             ],


### PR DESCRIPTION
We must provide a numeric default value for all columns which are stored as integer, otherwise the DataHandler falls back to an empty string which is rejected by MySQL in strict mode.