### PR TITLE
[BUGFIX] don't restore register

### DIFF
--- a/Configuration/TypoScript/Library/lib.dynamicContent.typoscript
+++ b/Configuration/TypoScript/Library/lib.dynamicContent.typoscript
@@ -113,7 +113,6 @@ lib.dynamicContent {
             required = 1
         }
     }
-    90 = RESTORE_REGISTER
 }
 lib.dynamicContentSlide =< lib.dynamicContent
 lib.dynamicContentSlide.20.slide = -1


### PR DESCRIPTION
to prevent register from theme_t3kit:s lib.dynamicContent to be restored when displaying content from other pages on a "category" page in product manager 