### PR TITLE
[BUGFIX] changed eval type for slug

### DIFF
--- a/Configuration/TCA/tx_pxaproductmanager_domain_model_product.php
+++ b/Configuration/TCA/tx_pxaproductmanager_domain_model_product.php
@@ -146,7 +146,7 @@ return (function () {
                         ],
                     ],
                     'fallbackCharacter' => '-',
-                    'eval' => 'uniqueInPid',
+                    'eval' => 'uniqueInSite',
                     'default' => '',
                 ],
             ],


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Issue in routing process, when there's 2 simillar slugs for records on different installations

Changed to "eval" => "uniqueForSite", so right now PersistedAliasMapper will only looking for slugs within current installation.