### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Latest Stable Version](https://poser.pugx.org/pixelant/pxa-product-manager/v/stable.svg)](https://extensions.typo3.org/extension/pxa_product_manager/)
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/pixelant/pxa-product-manager/d/total.svg)](https://packagist.org/packages/pixelant/pxa-product-manager)
+[![Monthly Downloads](https://poser.pugx.org/pixelant/pxa-product-manager/d/monthly)](https://packagist.org/packages/pixelant/pxa-product-manager)
+
 # Pixelant
 
 ## Pixelant Product Manager (pxa_product_manager)

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
   "name": "pixelant/pxa-product-manager",
   "type": "typo3-cms-extension",
   "description": "Create and list products on a site.",
+  "homepage": "https://extensions.typo3.org/extension/pxa_product_manager",
+  "support": {
+	"docs": "https://docs.typo3.org/p/pixelant/pxa-product-manager/master/en-us",
+	"issues": "https://github.com/pixelant/pxa_product_manager/issues",
+	"source": "https://github.com/pixelant/pxa_product_manager"
+  },
   "license": ["GPL-2.0-or-later"],
   "keywords": ["TYPO3 CMS"],
   "authors": [


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

In addition, the [TER homepage](https://extensions.typo3.org/extension/pxa_product_manager) is missing the "Packagist" button, which seems to be caused by the empty "Composer name of extension" fields in the TER extension edit form.

Relates: TYPO3-Documentation/T3DocTeam#185