### PR TITLE
Fix undefined array index in DetectSerializedValue Solr hook

### DIFF
--- a/Classes/Hook/Solr/DetectSerializedValue.php
+++ b/Classes/Hook/Solr/DetectSerializedValue.php
@@ -25,6 +25,10 @@ class DetectSerializedValue implements SerializedValueDetector
      */
     public function isSerializedValue(array $indexingConfiguration, $solrFieldName): bool
     {
+        if (!array_key_exists('userFunc', $indexingConfiguration[$solrFieldName . '.'])) {
+            return false;
+        }
+
         $userFunc = $indexingConfiguration[$solrFieldName . '.']['userFunc'];
         if (empty($userFunc)) {
             return false;


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

**System**

- Apache 2.5.54
- PHP 8.0
- TYPO3 11.5.24
- EXT:Solr 11.5.1
- Solr 11.5.1 -> [Docker Hub](https://hub.docker.com/r/typo3solr/ext-solr)

**Error message**

While indexing products the indexer throws the following error message for fields that do not have a user function defined. Like `keywords` for example.

```
1476107295: TYPO3\CMS\Core\Error\Exception: PHP Warning: Undefined array key "userFunc" in /path/to/pxa_product_manager/Classes/Hook/Solr/DetectSerializedValue.php line 32 in /path/to/public/typo3/sysext/core/Classes/Error/ErrorHandler.php:137
```