### PR TITLE
Fix Undefined "doktype" Errors

### DIFF
--- a/Configuration/TypoScript/TempPluginRenderer/ProductRender.typoscript
+++ b/Configuration/TypoScript/TempPluginRenderer/ProductRender.typoscript
@@ -1,4 +1,4 @@
-[page["doktype"] == 9]
+[page&&page["doktype"] == 9]
     lib.contentRender.45 = USER
     lib.contentRender.45 {
         stdWrap {


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Prevents TYPO3 11 Log getting flooded with the repeated error:

`Core: Error handler (BE): PHP Warning: Undefined array key "doktype" in /app/vendor/symfony/expression-language/Node/GetAttrNode.php line 97`